### PR TITLE
Fix docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For pre-built binaries, check the [releases page](https://github.com/leroy-merli
 ### Docker
 
 ```sh
-docker run leroymerlinbr/logstash_exporter:latest
+docker run leroymerlinbr/logstash-exporter:latest
 ```
 
 ### CLI


### PR DESCRIPTION
I think this is the right name for the docker image.

```
❯ docker run leroymerlinbr/logstash_exporter:latest
Unable to find image 'leroymerlinbr/logstash_exporter:latest' locally
docker: Error response from daemon: pull access denied for leroymerlinbr/logstash_exporter, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.

❯ docker run leroymerlinbr/logstash-exporter:latest
Unable to find image 'leroymerlinbr/logstash-exporter:latest' locally
latest: Pulling from leroymerlinbr/logstash-exporter
3032123d3b6e: Pull complete
Digest: sha256:0b69b6329e3874d44e9c9d209e0be9389f27bb1c72f15b3676b13ec292c11515
Status: Downloaded newer image for leroymerlinbr/logstash-exporter:latest
{"level":"info","time":"2022-05-26T05:59:44Z","message":"Starting logstash exporter..."}
{"level":"info","port":":9198","time":"2022-05-26T05:59:44Z","message":"Exporter started."}