### PR TITLE
feat: upgrade to go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 'Continuous Integration'
+name: "Continuous Integration"
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.22
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,4 @@
-name: 'Code Analysis'
+name: "Code Analysis"
 
 on:
   pull_request:
@@ -13,37 +13,37 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.22
 
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Setup Codacy Analyze Tool
         run: |
-         curl -L https://github.com/codacy/codacy-analysis-cli/archive/master.tar.gz | \
-         tar xvz && cd codacy-analysis-cli-* && sudo make install \
-         && cd .. && rm -rf master.* codacy-analysis-cli-*
+          curl -L https://github.com/codacy/codacy-analysis-cli/archive/master.tar.gz | \
+          tar xvz && cd codacy-analysis-cli-* && sudo make install \
+          && cd .. && rm -rf master.* codacy-analysis-cli-*
 
       - name: Run aligncheck
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
-         codacy-analysis-cli analyze --provider gh \
-         --username leroy-merlin-br \
-         --project logstash_exporter \
-         --tool aligncheck \
-         --allow-network \
-         --upload \
-         --verbose
+          codacy-analysis-cli analyze --provider gh \
+          --username leroy-merlin-br \
+          --project logstash_exporter \
+          --tool aligncheck \
+          --allow-network \
+          --upload \
+          --verbose
 
       - name: Run deadcode
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
-         codacy-analysis-cli analyze --provider gh \
-         --username leroy-merlin-br \
-         --project logstash_exporter \
-         --tool deadcode \
-         --allow-network \
-         --upload \
-         --verbose
+          codacy-analysis-cli analyze --provider gh \
+          --username leroy-merlin-br \
+          --project logstash_exporter \
+          --tool deadcode \
+          --allow-network \
+          --upload \
+          --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Create release'
+name: "Create release"
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.22
 
       - name: Bump version and push tag
         id: tag_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.7-alpine3.14 as build
+FROM golang:1.22.3-alpine3.20 as build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,20 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-go 1.16
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)
+
+go 1.22


### PR DESCRIPTION
Hi there. This upgrade fixes some CVE's present on go stdlib.

CVE list: CVE-2022-23806, CVE-2023-24540 and CVE-2023-24538.